### PR TITLE
Fix registered status check for .be domains

### DIFF
--- a/whois.be.php
+++ b/whois.be.php
@@ -52,7 +52,7 @@ class be_handler
 
 		$r['regrinfo'] = get_blocks($data['rawdata'], $items);
 
-		if ($r['regrinfo']['domain']['status'] == 'REGISTERED')
+		if ($r['regrinfo']['domain']['status'] != 'AVAILABLE')
 			{
 			$r['regrinfo']['registered'] = 'yes';
 			$r['regrinfo'] = get_contacts($r['regrinfo'],$trans);


### PR DESCRIPTION
The Belgian DNS provider does not set the "Status" flag to "REGISTERED",
but uses one of these three values: "AVAILABLE", "NOT AVAILABLE" and
"NOT ALLOWED".

See: http://www.dns.be/en/faq/faq_technical#1671

This minor patch should solve this right away.
